### PR TITLE
Fixed issue where struct fields were string

### DIFF
--- a/sdk/rpc_client.go
+++ b/sdk/rpc_client.go
@@ -362,12 +362,12 @@ type NamedKey struct {
 
 type AssociatedKey struct {
 	AccountHash string `json:"account_hash"`
-	Weight      string `json:"weight"`
+	Weight      uint64 `json:"weight"`
 }
 
 type ActionThresholds struct {
-	Deployment    string `json:"deployment"`
-	KeyManagement string `json:"key_management"`
+	Deployment    uint64 `json:"deployment"`
+	KeyManagement uint64 `json:"key_management"`
 }
 
 type JsonContractMetadata struct {


### PR DESCRIPTION
The `AssociatedKey `struct hash `Weight` for `string` when it should be `uint64`

Similarly, both fields for `ActionThresholds` should be `uint64`

Sample error message:
```
failed to get result: json: cannot unmarshal number into Go struct field ActionThresholds.stored_value.Account.action_thresholds.deployment of type string
```
